### PR TITLE
Raise exception if N_FRAMES_PER_CLIP is not a factor of number of frames

### DIFF
--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -72,7 +72,9 @@ def run_stac(
     if stac_cfg.skip_transform == 1:
         logging.info("skipping transform()")
         return fit_path, None
-
+    elif kp_data.shape[0] % model_cfg["N_FRAMES_PER_CLIP"] != 0:
+        raise ValueError(f"N_FRAMES_PER_CLIP ({model_cfg["N_FRAMES_PER_CLIP"]}) must be a factor of the number of mocap frames ({kp_data.shape[0]})")
+    
     logging.info("Running transform()")
     with open(fit_path, "rb") as file:
         fit_data = pickle.load(file)

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -73,8 +73,10 @@ def run_stac(
         logging.info("skipping transform()")
         return fit_path, None
     elif kp_data.shape[0] % model_cfg["N_FRAMES_PER_CLIP"] != 0:
-        raise ValueError(f"N_FRAMES_PER_CLIP ({model_cfg["N_FRAMES_PER_CLIP"]}) must be a factor of the number of mocap frames ({kp_data.shape[0]})")
-    
+        raise ValueError(
+            f"N_FRAMES_PER_CLIP ({model_cfg['N_FRAMES_PER_CLIP']}) must be a factor of the number of mocap frames ({kp_data.shape[0]})"
+        )
+
     logging.info("Running transform()")
     with open(fit_path, "rb") as file:
         fit_data = pickle.load(file)

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -74,7 +74,7 @@ def run_stac(
         return fit_path, None
     elif kp_data.shape[0] % model_cfg["N_FRAMES_PER_CLIP"] != 0:
         raise ValueError(
-            f"N_FRAMES_PER_CLIP ({model_cfg['N_FRAMES_PER_CLIP']}) must be a factor of the number of mocap frames ({kp_data.shape[0]})"
+            f"N_FRAMES_PER_CLIP ({model_cfg['N_FRAMES_PER_CLIP']}) must divide evenly with the total number of mocap frames({kp_data.shape[0]})"
         )
 
     logging.info("Running transform()")


### PR DESCRIPTION
This is to prevent unexpected behavior when preparing batches for `transform`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved data validation by adding a check to ensure the number of frames meets required constraints, preventing potential errors during processing.
	- Enhanced error messaging to provide clearer feedback when input data does not conform to expected parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->