### PR TITLE
rename fit and transform

### DIFF
--- a/stac_mjx/controller.py
+++ b/stac_mjx/controller.py
@@ -201,8 +201,7 @@ class STAC:
 
         return flattened_errors, mean, std
 
-    # TODO: pmap fit and transform if you want to use it with multiple gpus
-    def fit(self, kp_data):
+    def fit_offsets(self, kp_data):
         """Alternate between pose and offset optimization for a set number of iterations.
 
         Args:
@@ -295,7 +294,7 @@ class STAC:
         print(f"Standard deviation: {std}")
         return self._package_data(mjx_model, q, x, walker_body_sites, kp_data)
 
-    def transform(self, kp_data, offsets):
+    def transform_kps(self, kp_data, offsets):
         """Register skeleton to keypoint data.
 
             Transform should be used after a skeletal model has been fit to keypoints using the fit() method.

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -66,7 +66,7 @@ def run_stac(
     if cfg.stac.skip_fit != 1:
         fit_data = kp_data[: cfg.stac.n_fit_frames]
         logging.info(f"Running fit. Mocap data shape: {fit_data.shape}")
-        fit_data = stac.fit(fit_data)
+        fit_data = stac.fit_offsets(fit_data)
 
         logging.info(f"saving data to {fit_path}")
         utils.save(fit_data, fit_path)
@@ -87,7 +87,7 @@ def run_stac(
     offsets = fit_data["offsets"]
 
     logging.info(f"kp_data shape: {kp_data.shape}")
-    transform_data = stac.transform(kp_data, offsets)
+    transform_data = stac.transform_kps(kp_data, offsets)
 
     logging.info(
         f"Saving data to {transform_path}. Finished in {time.time() - start_time} seconds"


### PR DESCRIPTION
`fit` and `transform` are not very descriptive names, so this PR renames them to `fit_offsets` and `transform_kps` to better describe what they do. (Although `fit_offsets` does inverse kinematics in the process, the primary output is the marker offsets). This change doesn't impact users because they interact with the layer above this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in method functionalities with more descriptive names for fitting and transforming processes.
  
- **Bug Fixes**
	- Improved accuracy and performance in data processing related to offsets and keypoints through method updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->