### PR TITLE
Offset shape bugfix

### DIFF
--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -4,7 +4,7 @@ data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
 skip_fit_offsets: False
-ik_only: True
+skip_ik_only: True
 
 mujoco:
   solver: "newton"

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -1,4 +1,4 @@
-fit_path: "demo_fit.p"
+fit_offsets_path: "demo_fit.p"
 ik_only_path: "demo_ik_only.p"
 data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 

--- a/configs/stac/stac.yaml
+++ b/configs/stac/stac.yaml
@@ -1,4 +1,4 @@
-fit_path: "fit.p"
+fit_offsets_path: "fit.p"
 ik_only_path: "ik_only.p"
 data_path: "tests/data/test_rodent_mocap_1000_frames.nwb"
 

--- a/configs/stac/stac_fly_tethered.yaml
+++ b/configs/stac/stac_fly_tethered.yaml
@@ -1,5 +1,5 @@
-fit_path: "Fruitfly_fit.p"
-transform_path: "transform_mocap_fly.h5"
+fit_offsets_path: "Fruitfly_fit.p"
+ik_only_path: "transform_mocap_fly.h5"
 # This data is unpublished, need to speak to Elliot Abe about how to obtain it.
 # A possible source is https://datadryad.org/stash/dataset/doi:10.5061/dryad.nzs7h44s4
 # See the discussion here for more info: 

--- a/configs/stac/stac_fly_treadmill.yaml
+++ b/configs/stac/stac_fly_treadmill.yaml
@@ -1,5 +1,5 @@
-fit_path: "fly_treadmill_fit.p"
-transform_path: "transform_treadmill.p"
+fit_offsets_path: "fly_treadmill_fit.p"
+ik_only_path: "transform_treadmill.p"
 # File is too large to commit
 # DL from: https://datadryad.org/stash/dataset/doi:10.5061/dryad.mpg4f4r73
 # Actual file: https://datadryad.org/stash/downloads/file_stream/3361804

--- a/configs/stac/stac_mouse.yaml
+++ b/configs/stac/stac_mouse.yaml
@@ -1,4 +1,4 @@
-fit_path: "fit_mouse.p"
+fit_offsets_path: "fit_mouse.p"
 ik_only_path: "ik_only_mouse.p"
 data_path: "tests/data/test_mouse_mocap_3600_frames.h5"
 

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -56,7 +56,7 @@ def run_stac(
     start_time = time.time()
 
     # Getting paths
-    fit_path = base_path / cfg.stac.fit_path
+    fit_offsets_path = base_path / cfg.stac.fit_offsets_path
     ik_only_path = base_path / cfg.stac.ik_only_path
 
     xml_path = base_path / cfg.model.MJCF_PATH
@@ -69,13 +69,13 @@ def run_stac(
         logging.info(f"Running fit. Mocap data shape: {fit_data.shape}")
         fit_data = stac.fit_offsets(fit_data)
 
-        logging.info(f"saving data to {fit_path}")
-        io.save(fit_data, fit_path)
+        logging.info(f"saving data to {fit_offsets_path}")
+        io.save(fit_data, fit_offsets_path)
 
     # Stop here if not doing ik only phase
     if cfg.stac.skip_ik_only == 1:
         logging.info("skipping ik_only()")
-        return fit_path, None
+        return fit_offsets_path, None
     # FLY_MODEL: The elif below must be commented out for fly_model.
     elif kp_data.shape[0] % cfg.model.N_FRAMES_PER_CLIP != 0:
         raise ValueError(
@@ -83,7 +83,7 @@ def run_stac(
         )
 
     logging.info("Running ik_only()")
-    with open(fit_path, "rb") as file:
+    with open(fit_offsets_path, "rb") as file:
         fit_data = pickle.load(file)
     offsets = fit_data["offsets"]
 
@@ -95,4 +95,4 @@ def run_stac(
     )
     io.save(ik_only_data, ik_only_path)
 
-    return fit_path, ik_only_path
+    return fit_offsets_path, ik_only_path

--- a/stac_mjx/stac.py
+++ b/stac_mjx/stac.py
@@ -390,7 +390,7 @@ class Stac:
             x = x.reshape(-1, x.shape[-1])
             q = q.reshape(-1, q.shape[-1])
         else:
-            offsets = self._offsets
+            offsets = self._offsets.reshape((-1,3))
 
         kp_data = kp_data.reshape(-1, kp_data.shape[-1])
 

--- a/stac_mjx/stac.py
+++ b/stac_mjx/stac.py
@@ -390,7 +390,7 @@ class Stac:
             x = x.reshape(-1, x.shape[-1])
             q = q.reshape(-1, q.shape[-1])
         else:
-            offsets = self._offsets.reshape((-1,3))
+            offsets = self._offsets.reshape((-1, 3))
 
         kp_data = kp_data.reshape(-1, kp_data.shape[-1])
 

--- a/tests/configs/stac/test_stac.yaml
+++ b/tests/configs/stac/test_stac.yaml
@@ -1,4 +1,4 @@
-fit_path: "fit.p"
+fit_offsets_path: "fit.p"
 ik_only_path: "ik_only.p"
 data_path: "tests/data/test_rodent_mocap_1000_frames.nwb"
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,5 +18,5 @@ def test_load_configs(config):
     assert isinstance(cfg, DictConfig)
 
     # Assert that the resulting configs contain the expected data
-    assert cfg.stac.fit_path == "fit.p"
+    assert cfg.stac.fit_offsets_path == "fit.p"
     assert cfg.model.N_FRAMES_PER_CLIP == 360


### PR DESCRIPTION
Reshape offset when saving from `fit_offsets`

Also updated `run_stac.py` and stac config files to work with renamed values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated parameter names for improved clarity in configuration settings.
		- Renamed `fit_path` to `fit_offsets_path` across multiple configuration files.
		- Replaced `ik_only` with `skip_ik_only` in relevant configurations to clarify functionality.
- **Bug Fixes**
	- Updated test assertions to reflect the new naming conventions in configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->