### PR TITLE
Smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       
       # Test probably delete this
-      - name: Test run
+      - name: Smoke Test
         shell: bash -l {0}
         run: python run_stac.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           fail_ci_if_error: true
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
-  
-  # Run stac-mjx
-  python run-stac.py
+      
+      # Test probably delete this
+      - name: Test run
+        shell: bash -l {0}
+        run: python run_stac.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,6 @@ jobs:
           fail_ci_if_error: true
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+  
+  # Run stac-mjx
+  python run-stac.py

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -3,8 +3,8 @@ ik_only_path: "demo_ik_only.p"
 data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
-skip_fi_offsets: False
-skip_ik_onl: True
+skip_fit_offsets: False
+skip_ik_only: True
 
 mujoco:
   solver: "newton"

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -4,7 +4,7 @@ data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
 skip_fit_offsets: False
-skip_ik_only: False
+skip_ik_only: True
 
 mujoco:
   solver: "newton"

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -3,7 +3,7 @@ ik_only_path: "demo_ik_only.p"
 data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
-skip_fit_offsets: False
+skip_fi_offsets: False
 skip_ik_onl: True
 
 mujoco:

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -4,7 +4,7 @@ data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
 skip_fit_offsets: False
-skip_ik_only: True
+skip_ik_onl: True
 
 mujoco:
   solver: "newton"

--- a/configs/stac/demo.yaml
+++ b/configs/stac/demo.yaml
@@ -4,7 +4,7 @@ data_path: "tests/data/test_rodent_mocap_1000_frames.mat"
 
 n_fit_frames: 1
 skip_fit_offsets: False
-skip_ik_only: True
+skip_ik_only: False
 
 mujoco:
   solver: "newton"


### PR DESCRIPTION
Sets up a basic [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)) to check that `stac-mjx` isn't broken.

Good news:
- We'll now have way to tell when a commit breaks all of stac-mjx (fit_offsets() part.)

Bad news:
- CI testing now takes ~ 8 mins. 
- ik_only() is not included yet.
