### PR TITLE
Resolve reshape bug

### DIFF
--- a/stac_mjx/io.py
+++ b/stac_mjx/io.py
@@ -218,7 +218,7 @@ def load_h5(filename):
     Returns:
         dict: Dictionary containing the data from the .h5 file.
     """
-    # TODO add track information
+    # TODO tracks is a hardcoded dataset name
     data = {}
     with h5py.File(filename, "r") as f:
         for key in f.keys():
@@ -251,34 +251,6 @@ def _todict(matobj):
         else:
             dict[strg] = elem
     return dict
-
-
-def _load_params(param_path):
-    """Load parameters for the animal.
-
-    :param param_path: Path to .yaml file specifying animal parameters.
-    """
-    with open(param_path, "r") as infile:
-        try:
-            params = yaml.safe_load(infile)
-        except yaml.YAMLError as exc:
-            print(exc)
-    return params
-
-
-def save_dict_to_hdf5(group, dictionary):
-    """Save a dictionary to an HDF5 group.
-
-    Args:
-        group (h5py.Group): HDF5 group to save the dictionary to.
-        dictionary (dict): Dictionary to save.
-    """
-    for key, value in dictionary.items():
-        if isinstance(value, dict):
-            subgroup = group.create_group(key)
-            save_dict_to_hdf5(subgroup, value)
-        else:
-            group.attrs[key] = value
 
 
 def save_data_to_h5(

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -115,9 +115,7 @@ def run_stac(
     )
     if cfg.stac.infer_qvels:
         t_vel = time.time()
-        qvels = vmap_compute_velocity_fn(
-            qpos_trajectory=batched_qpos, freejoint=stac._freejoint
-        )
+        qvels = vmap_compute_velocity_fn(qpos_trajectory=batched_qpos)
         # set dict key after reshaping and casting to numpy
         ik_only_data.qvel = np.array(qvels).reshape(-1, *qvels.shape[2:])
         print(f"Finished compute velocity in {time.time() - t_vel}")

--- a/stac_mjx/viz.py
+++ b/stac_mjx/viz.py
@@ -51,6 +51,7 @@ def viz_stac(
     # initialize stac to create mj_model with scaling and marker body sites according to config
     # Set the learned offsets for body sites manually
     stac = Stac(xml_path, cfg, kp_names)
+
     return cfg, stac.render(
         qposes,
         kp_data,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -28,8 +28,6 @@ def test_load_nwb(config, mocap_nwb):
     """
     Test loading data from .nwb file.
     """
-    # params = utils._load_params(_BASE_PATH / rodent_config)
-    # assert params is not None
     cfg = load_config_with_overrides(config, stac_data_path_override=mocap_nwb)
     data, sorted_kp_names = io.load_mocap(cfg)
     assert data.shape == (1000, 69)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -28,8 +28,6 @@ def test_load_nwb(config, mocap_nwb):
     """
     Test loading data from .nwb file.
     """
-    # params = utils._load_params(_BASE_PATH / rodent_config)
-    # assert params is not None
     cfg = load_config_with_overrides(config, stac_data_path_override=mocap_nwb)
     data, sorted_kp_names = io.load_mocap(cfg)
     assert data.shape == (1000, 69)


### PR DESCRIPTION
`xpos` and `xquat` were being misordered from `reshape(order='C')`. Resolved by using `reshape(order='F')`. 

Also did some cleanup in the process :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal processing by removing redundant routines and renaming methods for enhanced clarity.
  - Optimized multidimensional data handling and simplified configuration management to improve maintainability.

- **Documentation**
  - Clarified inline comments to better explain dataset usage and internal logic.

- **Tests**
  - Cleaned up test code by removing obsolete, commented-out lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->