### PR TITLE
Move MOCAP_SCALE_FACTOR scaling from io.load_data() to run_stac()

### DIFF
--- a/demos/run_stac_fly_model.py
+++ b/demos/run_stac_fly_model.py
@@ -33,7 +33,7 @@ def parse_hydra_config(cfg: DictConfig):
     df_names = [kp + coord for kp in kp_names for coord in coords]
     kp_data_all = tredmill_data[df_names].values
     sorted_kp_names = kp_names
-    kp_data = model_cfg["MOCAP_SCALE_FACTOR"] * kp_data_all.copy()
+    kp_data = kp_data_all.copy()
 
     # import stac_mjx.io_dict_to_hdf5 as ioh5
     # data_path = base_path / stac_cfg.data_path

--- a/stac_mjx/io.py
+++ b/stac_mjx/io.py
@@ -53,9 +53,8 @@ def load_data(cfg: DictConfig, base_path: Union[Path, None] = None):
     Returns:
         Mocap data flattened into an np array of shape [#frames, keypointXYZ],
         where 'keypointXYZ' represents the flattened 3D keypoint components.
-        The data is also scaled by multiplication with "MOCAP_SCALE_FACTOR", e.g.
-        if the mocap data is in mm and the model is in meters, this should be
-        0.001.
+        Data is returned in its original units; MOCAP_SCALE_FACTOR scaling
+        is applied by run_stac().
 
     Raises:
         ValueError if an unsupported filetype is encountered.
@@ -98,8 +97,6 @@ def load_data(cfg: DictConfig, base_path: Union[Path, None] = None):
 
     sorted_kp_names = [kp_names[i] for i in model_inds]
 
-    # Scale mocap data to match model
-    data = data * cfg.model.MOCAP_SCALE_FACTOR
     # Sort in kp_names order
     data = jnp.array(data[:, :, model_inds])
     # Flatten data from [#num frames, #keypoints, xyz]

--- a/stac_mjx/main.py
+++ b/stac_mjx/main.py
@@ -37,9 +37,12 @@ def run_stac(
 ) -> tuple[str, str]:
     """High level function for running skeletal registration.
 
+    kp_data should be in raw (unscaled) units. It will be scaled internally
+    by cfg.model.MOCAP_SCALE_FACTOR before being passed to the fitting routines.
+
     Args:
         cfg (DictConfig): Configs.
-        kp_data (jp.ndarray): Mocap keypoints to fit to.
+        kp_data (jp.ndarray): Mocap keypoints to fit to, in raw units.
         kp_names (List[str]): Ordered list of keypoint names.
         base_path (Path, optional): Base path for reference files in configs. Defaults to Path.cwd().
 
@@ -67,6 +70,9 @@ def run_stac(
     ik_only_path = base_path / cfg.stac.ik_only_path
 
     xml_path = base_path / cfg.model.MJCF_PATH
+
+    # Scale mocap data to match model units
+    kp_data = kp_data * cfg.model.MOCAP_SCALE_FACTOR
 
     stac = Stac(xml_path, cfg, kp_names)
 

--- a/stac_mjx/stac.py
+++ b/stac_mjx/stac.py
@@ -217,7 +217,9 @@ class Stac:
         """Alternate between pose and offset optimization for a set number of iterations.
 
         Args:
-            kp_data (jp.ndarray): Mocap keypoints to fit to
+            kp_data (jp.ndarray): Mocap keypoints to fit to, in model units
+                (i.e. already scaled by MOCAP_SCALE_FACTOR). When called via
+                run_stac(), scaling is applied automatically.
 
         Returns:
             Dict: Output data packaged in a dictionary.
@@ -328,10 +330,11 @@ class Stac:
             will contain identical data.)
 
         Args:
-            mj_model (mujoco.Model): Physics model.
-            kp_data (jp.ndarray): Keypoint data in meters with shape
+            kp_data (jp.ndarray): Keypoint data in model units (i.e. already
+                scaled by MOCAP_SCALE_FACTOR) with shape
                 (n_frames, 3 * n_keypoints). Keypoint order must match the
-                order in the skeleton file.
+                order in the skeleton file. When called via run_stac(),
+                scaling is applied automatically.
             offsets (jp.ndarray): offsets loaded from offset.p after fit()
         """
         # Create batches of kp_data

--- a/tests/unit/test_main_run_stac.py
+++ b/tests/unit/test_main_run_stac.py
@@ -49,7 +49,7 @@ def make_cfg(
         infer_qvels=infer_qvels,
         continuous=continuous,
     )
-    model = types.SimpleNamespace(MJCF_PATH="models/rodent.xml")
+    model = types.SimpleNamespace(MJCF_PATH="models/rodent.xml", MOCAP_SCALE_FACTOR=1.0)
     return types.SimpleNamespace(stac=stac, model=model)
 
 
@@ -112,3 +112,27 @@ def test_run_stac_validates_kp_data_shape(monkeypatch):
 
     with pytest.raises(ValueError, match="kp_data"):
         main.run_stac(cfg, kp_data, ["a", "b"])
+
+
+def test_run_stac_applies_mocap_scale_factor(monkeypatch):
+    """Verify that run_stac() scales kp_data by MOCAP_SCALE_FACTOR."""
+    cfg = make_cfg(skip_fit_offsets=False, skip_ik_only=True)
+    cfg.model.MOCAP_SCALE_FACTOR = 0.001
+
+    raw_kp_data = np.ones((4, 6))
+
+    captured = {}
+
+    class CapturingStac(DummyStac):
+        def fit_offsets(self, kps):
+            captured["fit_kps"] = np.array(kps)
+            return DummyData()
+
+    monkeypatch.setattr(main, "Stac", CapturingStac)
+    monkeypatch.setattr(main.utils, "enable_xla_flags", lambda: None)
+    monkeypatch.setattr(main.io, "save_data_to_h5", lambda *args, **kwargs: None)
+
+    main.run_stac(cfg, raw_kp_data, ["a", "b"])
+
+    expected = raw_kp_data[:2] * 0.001  # n_fit_frames=2
+    np.testing.assert_allclose(captured["fit_kps"], expected)


### PR DESCRIPTION
## Summary

Fixes #95

- Move `MOCAP_SCALE_FACTOR` application from `io.load_data()` into `run_stac()`, the single public entry point where user data meets the model. This ensures users who provide custom keypoint data directly to `run_stac()` get correct scaling automatically, matching how `SCALE_FACTOR` is already applied at model init time.
- Remove manual pre-scaling from the fly demo (`demos/run_stac_fly_model.py`) since `run_stac()` now handles it.
- Update docstrings on `load_data()`, `fit_offsets()`, and `ik_only()` to document the new scaling contract.
- Add test verifying `run_stac()` applies `MOCAP_SCALE_FACTOR` to `kp_data`.

## Breaking changes

- **Users who manually pre-scale data before calling `run_stac()`**: Remove your manual scaling to avoid double-scaling. `run_stac()` now applies `MOCAP_SCALE_FACTOR` internally.
- **Users who call `load_data()` for purposes other than feeding into `run_stac()`**: Data is now returned unscaled. Apply `MOCAP_SCALE_FACTOR` yourself if needed.
- **Users who call `Stac.fit_offsets()`/`ik_only()` directly** (bypassing `run_stac()`): No change — you are still responsible for pre-scaling. Updated docstrings make this explicit.

## Test plan

- [x] `uv run black --check` passes on all changed files
- [x] All existing tests pass (`uv run pytest tests/`)
- [x] New test `test_run_stac_applies_mocap_scale_factor` verifies scaling is applied
- [ ] Manual review: `MOCAP_SCALE_FACTOR` is only applied in `run_stac()`