### PR TITLE
bug fix: root optimisation initialisation

### DIFF
--- a/stac_mjx/compute_stac.py
+++ b/stac_mjx/compute_stac.py
@@ -23,26 +23,28 @@ def root_optimization(
     trunk_kps: jp.ndarray,
     frame: int = 0,
 ):
-    """Optimize fit for only the root.
+    """Optimize the root DOFs for a single frame.
 
-    The root is optimized first so as to remove a common contribution to
-    to rest of the child nodes. The choice of "root" node is somewhat
-    aribitrary since the body model is an undirected graph. The root here
-    is intended to mean the node closest to the center of mass of the
-    animal at rest.
+    The root is optimized first to remove a common contribution to the rest of
+    the kinematic chain. This seeds the root translation from the selected root
+    keypoint in `kp_data` and then runs two root-only q-phase solves using the
+    trunk keypoints as the objective.
 
     Args:
-        mjx_model (mjx.Model): MJX Model
-        mjx_data (mjx.Data): MJX Data
-        kp_data (jp.Array): Keypoint data
+        stac_core_obj (stac_core.StacCore): Solver wrapper used for q-phase optimization.
+        mjx_model (mjx.Model): MJX model.
+        mjx_data (mjx.Data): MJX data.
+        kp_data (jp.ndarray): Flattened keypoint data with shape
+            `(n_frames, 3 * n_keypoints)`.
+        root_kp_idx (int): Index of the root keypoint in the ordered keypoint list.
         lb (jp.ndarray): Array of lower bounds for corresponding qpos elements
         ub (jp.ndarray): Array of upper bounds for corresponding qpos elements
         site_idxs (jp.ndarray): Array of indices of offset sites
-        trunk_kps (jp.ndarray): Array of indices of keypoints to optimize
+        trunk_kps (jp.ndarray): Boolean mask of trunk keypoints to optimize.
         frame (int, optional): Frame to optimize. Defaults to 0.
 
     Returns:
-        mjx.Data: An updated MJX Data
+        mjx.Data: Updated MJX data after root optimization.
     """
     print(f"Root Optimization:")
 
@@ -53,8 +55,8 @@ def root_optimization(
     print(f"Optimizing first {root_dims} qposes for root optimization")
     s = time.time()
     q0 = jp.copy(mjx_data.qpos[:])
-
-    q0.at[:3].set(kp_data[frame, :][root_kp_idx : root_kp_idx + 3])
+    root_xyz = kp_data[frame, 3 * root_kp_idx : 3 * root_kp_idx + 3]
+    q0 = q0.at[:3].set(root_xyz)
     qs_to_opt = jp.zeros_like(q0, dtype=bool)
     qs_to_opt = qs_to_opt.at[:root_dims].set(True)
     kps_to_opt = jp.repeat(trunk_kps, 3)
@@ -76,7 +78,7 @@ def root_optimization(
     )
 
     q0 = jp.copy(mjx_data.qpos[:])
-    q0.at[:3].set(kp_data[frame, :][root_kp_idx : root_kp_idx + 3])
+    q0 = q0.at[:3].set(root_xyz)
 
     # Trunk only optimization
     mjx_data, res = stac_core_obj.q_opt(

--- a/tests/unit/test_compute_stac.py
+++ b/tests/unit/test_compute_stac.py
@@ -33,10 +33,12 @@ class FakeStacCore:
     def __init__(self):
         self.q_calls = 0
         self.m_calls = 0
+        self.q0_args = []
 
     def q_opt(self, *args, **kwargs):
         self.q_calls += 1
         q0 = args[5]
+        self.q0_args.append(q0)
         res = types.SimpleNamespace(params=q0, state=types.SimpleNamespace(error=0.0))
         return args[1], res
 
@@ -81,6 +83,41 @@ def test_root_optimization_calls_q_opt_twice(monkeypatch):
 
     assert isinstance(out, FakeMjxData)
     assert stac_core.q_calls == 2
+
+
+def test_root_optimization_seeds_root_translation_from_correct_keypoint(monkeypatch):
+    monkeypatch.setattr(
+        compute_stac,
+        "mujoco",
+        types.SimpleNamespace(
+            mjtJoint=types.SimpleNamespace(mjJNT_SLIDE=1, mjJNT_FREE=0)
+        ),
+    )
+    monkeypatch.setattr(utils, "kinematics", lambda model, data: data)
+    monkeypatch.setattr(utils, "com_pos", lambda model, data: data)
+
+    stac_core = FakeStacCore()
+    initial_qpos = jp.array([91.0, 92.0, 93.0, 4.0, 5.0, 6.0, 7.0])
+    mjx_model = FakeMjxModel(nq=7, jnt_type=jp.array([0]), site_pos=jp.zeros((2, 3)))
+    mjx_data = FakeMjxData(qpos=initial_qpos)
+    kp_data = jp.array([[11.0, 12.0, 13.0, 21.0, 22.0, 23.0]])
+
+    compute_stac.root_optimization(
+        stac_core,
+        mjx_model,
+        mjx_data,
+        kp_data,
+        root_kp_idx=1,
+        lb=jp.zeros(7),
+        ub=jp.ones(7),
+        site_idxs=jp.array([0, 1]),
+        trunk_kps=jp.array([True, True]),
+    )
+
+    expected_q0 = jp.array([21.0, 22.0, 23.0, 4.0, 5.0, 6.0, 7.0])
+    assert stac_core.q_calls == 2
+    assert np.allclose(np.array(stac_core.q0_args[0]), np.array(expected_q0))
+    assert np.allclose(np.array(stac_core.q0_args[1]), np.array(expected_q0))
 
 
 def test_offset_optimization_updates_site_pos(monkeypatch):


### PR DESCRIPTION
Fixed a root initialisation bug in `root_optimization` where the seeded root translation was never applied because the JAX `.at[:3].set(...)` result was ignored, and where the root keypoint slice used the wrong indices for flattened (x, y, z) keypoint data. The PR updates the logic to assign the new q0 correctly and to slice root coordinates as `3 * root_kp_idx : 3 * root_kp_idx + 3`.

Also refreshed the root_optimization docstring to match the actual inputs and behavior, and added a focused regression test that verifies the correct root keypoint coordinates are passed into both q_opt calls.

A new test has also been added to test this fix.