### PR TITLE
Add stac-viewer CLI for interactive STAC fit replay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,13 @@ dev = [
     "mediapy",
     ]
 
+[project.scripts]
+stac-mjx = "stac_mjx.cli:main"
+stac-viewer = "stac_mjx.replay_fit:main"
+
 [project.urls]
 Homepage = "https://github.com/talmolab/stac-mjx"
 Repository = "https://github.com/talmolab/stac-mjx"
-
-[project.scripts]
-stac-mjx = "stac_mjx.cli:main"
 
 [tool.setuptools.packages.find]
 exclude = ["site"]

--- a/stac_mjx/__init__.py
+++ b/stac_mjx/__init__.py
@@ -4,3 +4,4 @@ from stac_mjx.utils import enable_xla_flags
 from stac_mjx.io import load_data
 from stac_mjx.main import load_configs, run_stac
 from stac_mjx.viz import viz_stac
+from stac_mjx.replay_fit import replay

--- a/stac_mjx/replay_fit.py
+++ b/stac_mjx/replay_fit.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Interactive MuJoCo viewer for replaying STAC fit results.
+
+Provides both a Python API (:func:`replay`) and a CLI entry point
+(``stac-viewer``) for animating STAC output H5 files in MuJoCo's
+passive viewer with optional keypoint / marker-site overlays.
+
+Examples::
+
+    # CLI
+    stac-viewer fit_offsets.h5
+    stac-viewer ik_only.h5 --xml models/rodent.xml --fps 60
+
+    # Python
+    from stac_mjx.replay_fit import replay
+    replay("fit_offsets.h5")
+"""
+
+import argparse
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+import h5py
+import mujoco
+import numpy as np
+import yaml
+
+
+_COMMON_ROOT_BODIES = ("torso", "reference_base", "thorax", "trunk", "body")
+
+
+def _resolve_xml_path(mjcf_path: str, h5_path: Union[str, Path]) -> Path:
+    """Find the MJCF XML on disk, searching several locations."""
+    p = Path(mjcf_path)
+    if p.is_absolute() and p.exists():
+        return p
+
+    h5_dir = Path(h5_path).resolve().parent
+    candidates = [
+        h5_dir / p,
+        h5_dir / p.name,
+        Path.cwd() / p,
+    ]
+    for c in candidates:
+        if c.exists():
+            return c.resolve()
+
+    raise FileNotFoundError(
+        f"Could not find MJCF model '{mjcf_path}'.\n"
+        "Searched:\n" + "\n".join(f"  {c}" for c in candidates) + "\n"
+        "Use --xml to specify the path explicitly."
+    )
+
+
+def _detect_root_body(model: mujoco.MjModel, hint: Optional[str] = None) -> int:
+    """Return the body id to track with the camera."""
+    if hint is not None:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, hint)
+        if bid >= 0:
+            return bid
+        raise ValueError(
+            f"Root body '{hint}' not found in model. "
+            f"Available bodies: {[mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]}"
+        )
+    for name in _COMMON_ROOT_BODIES:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+        if bid >= 0:
+            return bid
+    return 1  # first non-world body
+
+
+def _load_h5_for_replay(h5_path: Union[str, Path]) -> dict:
+    """Load STAC output H5 with minimal dependencies (h5py + numpy)."""
+    with h5py.File(h5_path, "r") as f:
+        result: dict = {}
+
+        if "config" in f:
+            config_yaml = f["config"][()].decode("utf-8")
+            result["config"] = yaml.safe_load(config_yaml)
+
+        if "qpos" not in f:
+            raise ValueError(
+                f"{h5_path} does not contain 'qpos'. "
+                "This does not look like a STAC output file."
+            )
+        result["qpos"] = f["qpos"][:]
+
+        for key in ("kp_data", "marker_sites"):
+            if key in f:
+                result[key] = f[key][:]
+
+    return result
+
+
+def _normalize_shapes(data: dict) -> dict:
+    """Flatten batched (n_clips, n_per_clip, ...) arrays to (n_frames, ...)."""
+    qpos = data["qpos"]
+    if qpos.ndim == 3:
+        data["qpos"] = qpos.reshape(-1, qpos.shape[-1])
+        for key in ("kp_data", "marker_sites"):
+            if key in data:
+                arr = data[key]
+                data[key] = arr.reshape(-1, *arr.shape[2:])
+
+    if "kp_data" in data and data["kp_data"].ndim == 2:
+        kp = data["kp_data"]
+        data["kp_data"] = kp.reshape(kp.shape[0], -1, 3)
+
+    if "marker_sites" in data and data["marker_sites"].ndim == 2:
+        ms = data["marker_sites"]
+        data["marker_sites"] = ms.reshape(ms.shape[0], -1, 3)
+
+    return data
+
+
+def _auto_sphere_size(model: mujoco.MjModel) -> float:
+    """Heuristic: sphere radius ~ 1/200 of the model's bounding extent."""
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    extents = data.xpos[1:].max(axis=0) - data.xpos[1:].min(axis=0)
+    extent = max(extents.max(), 0.01)
+    return float(extent / 200.0)
+
+
+def replay(
+    h5_path: Union[str, Path],
+    xml_path: Optional[Union[str, Path]] = None,
+    fps: Optional[float] = None,
+    scale: Optional[float] = None,
+    show_markers: bool = True,
+    sphere_size: Optional[float] = None,
+    root_body: Optional[str] = None,
+) -> None:
+    """Launch interactive MuJoCo viewer to replay a STAC fit.
+
+    Args:
+        h5_path: Path to a STAC output H5 file (from ``fit_offsets`` or
+            ``ik_only``).
+        xml_path: Path to the MJCF XML model. If *None*, auto-resolved
+            from the config embedded in the H5.
+        fps: Playback frames per second. If *None*, uses ``RENDER_FPS``
+            from the embedded config (default 30).
+        scale: Geometry scale factor. If *None*, uses ``SCALE_FACTOR``
+            from the embedded config (default 1.0).
+        show_markers: Overlay input keypoints (red) and fitted marker
+            sites (green) as debug spheres.
+        sphere_size: Radius of debug spheres in metres. If *None*,
+            auto-scaled from the model's bounding extent.
+        root_body: Name of the body the camera tracks. If *None*,
+            tries common names (``torso``, ``reference_base``, ...)
+            then falls back to the first non-world body.
+    """
+    h5_path = Path(h5_path).resolve()
+    if not h5_path.exists():
+        raise FileNotFoundError(f"H5 file not found: {h5_path}")
+
+    data = _load_h5_for_replay(h5_path)
+    config = data.get("config", {})
+    model_cfg = config.get("model", {})
+
+    if xml_path is None:
+        mjcf = model_cfg.get("MJCF_PATH")
+        if mjcf is None:
+            raise ValueError(
+                "No MJCF_PATH in the H5 config and --xml not provided."
+            )
+        xml_path = _resolve_xml_path(mjcf, h5_path)
+    else:
+        xml_path = Path(xml_path).resolve()
+        if not xml_path.exists():
+            raise FileNotFoundError(f"XML model not found: {xml_path}")
+
+    if scale is None:
+        scale = float(model_cfg.get("SCALE_FACTOR", 1.0))
+    if fps is None:
+        fps = float(model_cfg.get("RENDER_FPS", 30))
+
+    data = _normalize_shapes(data)
+    qpos = data["qpos"]
+    kp_data = data.get("kp_data")
+    marker_sites = data.get("marker_sites")
+    has_markers = show_markers and kp_data is not None and marker_sites is not None
+
+    model = mujoco.MjModel.from_xml_path(str(xml_path))
+    if scale != 1.0:
+        model.body_pos[:] *= scale
+        model.geom_pos[:] *= scale
+        model.geom_size[:] *= scale
+        model.site_pos[:] *= scale
+        if model.nmesh > 0:
+            model.mesh_vert[:] *= scale
+        print(f"  Model geometry scaled by {scale}")
+    mj_data = mujoco.MjData(model)
+
+    if qpos.shape[1] != model.nq:
+        raise ValueError(
+            f"qpos width {qpos.shape[1]} != model.nq {model.nq}. "
+            f"The H5 was probably fit against a different MJCF."
+        )
+
+    if sphere_size is None:
+        sphere_size = _auto_sphere_size(model)
+
+    root_body_id = _detect_root_body(model, root_body)
+    root_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, root_body_id)
+
+    n_frames = qpos.shape[0]
+    frame_dt = 1.0 / fps
+
+    floor_gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+    floor_step = 0.001
+
+    paused = False
+    speed_presets = (0.1, 0.25, 0.5, 1.0, 2.0)
+    speed_idx = speed_presets.index(1.0)
+    frame_idx = 0
+
+    print(f"Replaying {n_frames} frames from {h5_path.name}")
+    print(f"  XML: {xml_path}")
+    print(f"  qpos: {qpos.shape}, model.nq: {model.nq}")
+    if has_markers:
+        print(f"  kp_data: {kp_data.shape}, marker_sites: {marker_sites.shape}")
+    print(f"  FPS: {fps}, scale: {scale}, tracking body: '{root_name}' (id {root_body_id})")
+    print(f"  sphere_size: {sphere_size:.4f} m")
+    print()
+    print("Controls:")
+    print("  SPACE        pause / play")
+    print("  LEFT/RIGHT   step -1 / +1 frame")
+    print(f"  UP/DOWN      speed: {list(speed_presets)} (start 1.0x)")
+    if floor_gid >= 0:
+        print(f"  - / =        nudge floor z by +/- 1 mm")
+    if has_markers:
+        print("  Markers:  red = input keypoints,  green = fitted marker sites")
+    print()
+
+    last_cam_print = 0.0
+
+    def key_callback(keycode: int) -> None:
+        nonlocal paused, frame_idx, speed_idx
+        if keycode == 32:  # SPACE
+            paused = not paused
+            print(f"\n[{'PAUSED' if paused else 'PLAYING'}] frame {frame_idx}")
+        elif keycode == 263:  # LEFT
+            frame_idx = (frame_idx - 1) % n_frames
+            print(f"\n[STEP -] frame {frame_idx}")
+        elif keycode == 262:  # RIGHT
+            frame_idx = (frame_idx + 1) % n_frames
+            print(f"\n[STEP +] frame {frame_idx}")
+        elif keycode == 265:  # UP
+            speed_idx = min(speed_idx + 1, len(speed_presets) - 1)
+            print(f"\n[SPEED] {speed_presets[speed_idx]}x")
+        elif keycode == 264:  # DOWN
+            speed_idx = max(speed_idx - 1, 0)
+            print(f"\n[SPEED] {speed_presets[speed_idx]}x")
+        elif keycode in (45, 61) and floor_gid >= 0:  # '-' / '='
+            model.geom_pos[floor_gid, 2] += floor_step if keycode == 61 else -floor_step
+            wz = float(model.geom_pos[floor_gid, 2])
+            print(f"\n[FLOOR] z={wz:+.5f}")
+
+    import mujoco.viewer  # noqa: delayed so headless imports don't break
+
+    with mujoco.viewer.launch_passive(model, mj_data, key_callback=key_callback) as viewer:
+        viewer.cam.distance = sphere_size * 30
+        viewer.cam.elevation = -20.0
+        viewer.cam.azimuth = 90.0
+        if has_markers:
+            viewer.user_scn.ngeom = 0
+
+        while viewer.is_running():
+            t0 = time.time()
+
+            mj_data.qpos[:] = qpos[frame_idx]
+            mujoco.mj_forward(model, mj_data)
+            viewer.cam.lookat[:] = mj_data.xpos[root_body_id]
+
+            now = time.time()
+            if now - last_cam_print > 0.25:
+                lk = viewer.cam.lookat
+                print(
+                    f"\rframe {frame_idx:4d}/{n_frames}  "
+                    f"lookat=({lk[0]:+.4f},{lk[1]:+.4f},{lk[2]:+.4f})  "
+                    f"dist={viewer.cam.distance:.4f}  "
+                    f"az={viewer.cam.azimuth:6.1f}  el={viewer.cam.elevation:+5.1f}",
+                    end="", flush=True,
+                )
+                last_cam_print = now
+
+            if has_markers:
+                viewer.user_scn.ngeom = 0
+                sz = np.array([sphere_size, 0, 0])
+                identity = np.eye(3).flatten()
+                red = np.array([1.0, 0.2, 0.2, 1.0], dtype=np.float32)
+                green = np.array([0.2, 1.0, 0.2, 1.0], dtype=np.float32)
+
+                for p in kp_data[frame_idx]:
+                    if viewer.user_scn.ngeom >= viewer.user_scn.maxgeom:
+                        break
+                    mujoco.mjv_initGeom(
+                        viewer.user_scn.geoms[viewer.user_scn.ngeom],
+                        type=mujoco.mjtGeom.mjGEOM_SPHERE,
+                        size=sz,
+                        pos=p.astype(np.float64),
+                        mat=identity,
+                        rgba=red,
+                    )
+                    viewer.user_scn.ngeom += 1
+
+                for p in marker_sites[frame_idx]:
+                    if viewer.user_scn.ngeom >= viewer.user_scn.maxgeom:
+                        break
+                    mujoco.mjv_initGeom(
+                        viewer.user_scn.geoms[viewer.user_scn.ngeom],
+                        type=mujoco.mjtGeom.mjGEOM_SPHERE,
+                        size=sz,
+                        pos=p.astype(np.float64),
+                        mat=identity,
+                        rgba=green,
+                    )
+                    viewer.user_scn.ngeom += 1
+
+            viewer.sync()
+
+            if not paused:
+                frame_idx = (frame_idx + 1) % n_frames
+            dt = (frame_dt / speed_presets[speed_idx]) - (time.time() - t0)
+            if dt > 0:
+                time.sleep(dt)
+
+
+def main() -> None:
+    """CLI entry point for ``stac-viewer``."""
+    parser = argparse.ArgumentParser(
+        prog="stac-viewer",
+        description="Interactive MuJoCo viewer for STAC fit results.",
+    )
+    parser.add_argument(
+        "h5",
+        help="Path to a STAC output H5 file (fit_offsets or ik_only).",
+    )
+    parser.add_argument(
+        "--xml",
+        default=None,
+        help="Path to MJCF XML model. Auto-resolved from H5 config if omitted.",
+    )
+    parser.add_argument(
+        "--fps", type=float, default=None,
+        help="Playback fps (default: from H5 config, or 30).",
+    )
+    parser.add_argument(
+        "--scale", type=float, default=None,
+        help="Geometry scale factor (default: from H5 config, or 1.0).",
+    )
+    parser.add_argument(
+        "--no-markers", action="store_true",
+        help="Don't overlay input keypoints / marker sites.",
+    )
+    parser.add_argument(
+        "--sphere-size", type=float, default=None,
+        help="Radius (m) of debug spheres (default: auto-scaled from model).",
+    )
+    parser.add_argument(
+        "--root-body", default=None,
+        help="Body name for camera tracking (default: auto-detect).",
+    )
+    args = parser.parse_args()
+
+    replay(
+        h5_path=args.h5,
+        xml_path=args.xml,
+        fps=args.fps,
+        scale=args.scale,
+        show_markers=not args.no_markers,
+        sphere_size=args.sphere_size,
+        root_body=args.root_body,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/stac_mjx/replay_fit.py
+++ b/stac_mjx/replay_fit.py
@@ -26,7 +26,6 @@ import mujoco
 import numpy as np
 import yaml
 
-
 _COMMON_ROOT_BODIES = ("torso", "reference_base", "thorax", "trunk", "body")
 
 
@@ -162,9 +161,7 @@ def replay(
     if xml_path is None:
         mjcf = model_cfg.get("MJCF_PATH")
         if mjcf is None:
-            raise ValueError(
-                "No MJCF_PATH in the H5 config and --xml not provided."
-            )
+            raise ValueError("No MJCF_PATH in the H5 config and --xml not provided.")
         xml_path = _resolve_xml_path(mjcf, h5_path)
     else:
         xml_path = Path(xml_path).resolve()
@@ -221,7 +218,9 @@ def replay(
     print(f"  qpos: {qpos.shape}, model.nq: {model.nq}")
     if has_markers:
         print(f"  kp_data: {kp_data.shape}, marker_sites: {marker_sites.shape}")
-    print(f"  FPS: {fps}, scale: {scale}, tracking body: '{root_name}' (id {root_body_id})")
+    print(
+        f"  FPS: {fps}, scale: {scale}, tracking body: '{root_name}' (id {root_body_id})"
+    )
     print(f"  sphere_size: {sphere_size:.4f} m")
     print()
     print("Controls:")
@@ -260,7 +259,9 @@ def replay(
 
     import mujoco.viewer  # noqa: delayed so headless imports don't break
 
-    with mujoco.viewer.launch_passive(model, mj_data, key_callback=key_callback) as viewer:
+    with mujoco.viewer.launch_passive(
+        model, mj_data, key_callback=key_callback
+    ) as viewer:
         viewer.cam.distance = sphere_size * 30
         viewer.cam.elevation = -20.0
         viewer.cam.azimuth = 90.0
@@ -282,7 +283,8 @@ def replay(
                     f"lookat=({lk[0]:+.4f},{lk[1]:+.4f},{lk[2]:+.4f})  "
                     f"dist={viewer.cam.distance:.4f}  "
                     f"az={viewer.cam.azimuth:6.1f}  el={viewer.cam.elevation:+5.1f}",
-                    end="", flush=True,
+                    end="",
+                    flush=True,
                 )
                 last_cam_print = now
 
@@ -344,23 +346,31 @@ def main() -> None:
         help="Path to MJCF XML model. Auto-resolved from H5 config if omitted.",
     )
     parser.add_argument(
-        "--fps", type=float, default=None,
+        "--fps",
+        type=float,
+        default=None,
         help="Playback fps (default: from H5 config, or 30).",
     )
     parser.add_argument(
-        "--scale", type=float, default=None,
+        "--scale",
+        type=float,
+        default=None,
         help="Geometry scale factor (default: from H5 config, or 1.0).",
     )
     parser.add_argument(
-        "--no-markers", action="store_true",
+        "--no-markers",
+        action="store_true",
         help="Don't overlay input keypoints / marker sites.",
     )
     parser.add_argument(
-        "--sphere-size", type=float, default=None,
+        "--sphere-size",
+        type=float,
+        default=None,
         help="Radius (m) of debug spheres (default: auto-scaled from model).",
     )
     parser.add_argument(
-        "--root-body", default=None,
+        "--root-body",
+        default=None,
         help="Body name for camera tracking (default: auto-detect).",
     )
     args = parser.parse_args()

--- a/stac_mjx/replay_fit.py
+++ b/stac_mjx/replay_fit.py
@@ -16,10 +16,11 @@ Examples::
     replay("fit_offsets.h5")
 """
 
+from __future__ import annotations
+
 import argparse
 import time
 from pathlib import Path
-from typing import Optional, Union
 
 import h5py
 import mujoco
@@ -29,7 +30,7 @@ import yaml
 _COMMON_ROOT_BODIES = ("torso", "reference_base", "thorax", "trunk", "body")
 
 
-def _resolve_xml_path(mjcf_path: str, h5_path: Union[str, Path]) -> Path:
+def _resolve_xml_path(mjcf_path: str, h5_path: str | Path) -> Path:
     """Find the MJCF XML on disk, searching several locations."""
     p = Path(mjcf_path)
     if p.is_absolute() and p.exists():
@@ -52,7 +53,7 @@ def _resolve_xml_path(mjcf_path: str, h5_path: Union[str, Path]) -> Path:
     )
 
 
-def _detect_root_body(model: mujoco.MjModel, hint: Optional[str] = None) -> int:
+def _detect_root_body(model: mujoco.MjModel, hint: str | None = None) -> int:
     """Return the body id to track with the camera."""
     if hint is not None:
         bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, hint)
@@ -69,7 +70,7 @@ def _detect_root_body(model: mujoco.MjModel, hint: Optional[str] = None) -> int:
     return 1  # first non-world body
 
 
-def _load_h5_for_replay(h5_path: Union[str, Path]) -> dict:
+def _load_h5_for_replay(h5_path: str | Path) -> dict:
     """Load STAC output H5 with minimal dependencies (h5py + numpy)."""
     with h5py.File(h5_path, "r") as f:
         result: dict = {}
@@ -113,23 +114,25 @@ def _normalize_shapes(data: dict) -> dict:
     return data
 
 
-def _auto_sphere_size(model: mujoco.MjModel) -> float:
-    """Heuristic: sphere radius ~ 1/200 of the model's bounding extent."""
+def _model_extent(model: mujoco.MjModel) -> float:
+    """Return the bounding extent of all non-world bodies."""
     data = mujoco.MjData(model)
     mujoco.mj_forward(model, data)
-    extents = data.xpos[1:].max(axis=0) - data.xpos[1:].min(axis=0)
-    extent = max(extents.max(), 0.01)
-    return float(extent / 200.0)
+    body_xpos = data.xpos[1:]
+    if body_xpos.size == 0:
+        return 0.01
+    extents = body_xpos.max(axis=0) - body_xpos.min(axis=0)
+    return float(max(extents.max(), 0.01))
 
 
 def replay(
-    h5_path: Union[str, Path],
-    xml_path: Optional[Union[str, Path]] = None,
-    fps: Optional[float] = None,
-    scale: Optional[float] = None,
+    h5_path: str | Path,
+    xml_path: str | Path | None = None,
+    fps: float | None = None,
+    scale: float | None = None,
     show_markers: bool = True,
-    sphere_size: Optional[float] = None,
-    root_body: Optional[str] = None,
+    sphere_size: float | None = None,
+    root_body: str | None = None,
 ) -> None:
     """Launch interactive MuJoCo viewer to replay a STAC fit.
 
@@ -150,6 +153,8 @@ def replay(
             tries common names (``torso``, ``reference_base``, ...)
             then falls back to the first non-world body.
     """
+    from stac_mjx.rescale import dm_scale_spec
+
     h5_path = Path(h5_path).resolve()
     if not h5_path.exists():
         raise FileNotFoundError(f"H5 file not found: {h5_path}")
@@ -179,15 +184,11 @@ def replay(
     marker_sites = data.get("marker_sites")
     has_markers = show_markers and kp_data is not None and marker_sites is not None
 
-    model = mujoco.MjModel.from_xml_path(str(xml_path))
+    spec = mujoco.MjSpec.from_file(str(xml_path))
     if scale != 1.0:
-        model.body_pos[:] *= scale
-        model.geom_pos[:] *= scale
-        model.geom_size[:] *= scale
-        model.site_pos[:] *= scale
-        if model.nmesh > 0:
-            model.mesh_vert[:] *= scale
+        spec = dm_scale_spec(spec, scale)
         print(f"  Model geometry scaled by {scale}")
+    model = spec.compile()
     mj_data = mujoco.MjData(model)
 
     if qpos.shape[1] != model.nq:
@@ -196,8 +197,9 @@ def replay(
             f"The H5 was probably fit against a different MJCF."
         )
 
+    extent = _model_extent(model)
     if sphere_size is None:
-        sphere_size = _auto_sphere_size(model)
+        sphere_size = extent / 200.0
 
     root_body_id = _detect_root_body(model, root_body)
     root_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, root_body_id)
@@ -262,7 +264,7 @@ def replay(
     with mujoco.viewer.launch_passive(
         model, mj_data, key_callback=key_callback
     ) as viewer:
-        viewer.cam.distance = sphere_size * 30
+        viewer.cam.distance = extent * 2.0
         viewer.cam.elevation = -20.0
         viewer.cam.azimuth = 90.0
         if has_markers:

--- a/tests/test_replay_fit.py
+++ b/tests/test_replay_fit.py
@@ -1,0 +1,246 @@
+"""Tests for stac_mjx.replay_fit helper functions."""
+
+from pathlib import Path
+
+import h5py
+import mujoco
+import numpy as np
+import pytest
+
+from stac_mjx.replay_fit import (
+    _detect_root_body,
+    _load_h5_for_replay,
+    _model_extent,
+    _normalize_shapes,
+    _resolve_xml_path,
+)
+
+RODENT_XML = Path("models/rodent.xml")
+
+
+# --- _resolve_xml_path ---
+
+
+def test_resolve_xml_path_relative_to_h5(tmp_path):
+    xml = tmp_path / "model.xml"
+    xml.write_text("<mujoco/>")
+    h5 = tmp_path / "fit.h5"
+
+    result = _resolve_xml_path("model.xml", h5)
+    assert result == xml.resolve()
+
+
+def test_resolve_xml_path_nested_relative_to_h5(tmp_path):
+    (tmp_path / "models").mkdir()
+    xml = tmp_path / "models" / "robot.xml"
+    xml.write_text("<mujoco/>")
+    h5 = tmp_path / "fit.h5"
+
+    result = _resolve_xml_path("models/robot.xml", h5)
+    assert result == xml.resolve()
+
+
+def test_resolve_xml_path_basename_fallback(tmp_path):
+    xml = tmp_path / "robot.xml"
+    xml.write_text("<mujoco/>")
+    h5 = tmp_path / "fit.h5"
+
+    result = _resolve_xml_path("some/other/path/robot.xml", h5)
+    assert result == xml.resolve()
+
+
+def test_resolve_xml_path_not_found(tmp_path):
+    h5 = tmp_path / "fit.h5"
+    with pytest.raises(FileNotFoundError, match="Could not find MJCF"):
+        _resolve_xml_path("nonexistent.xml", h5)
+
+
+def test_resolve_xml_path_absolute(tmp_path):
+    xml = tmp_path / "model.xml"
+    xml.write_text("<mujoco/>")
+
+    result = _resolve_xml_path(str(xml), tmp_path / "fit.h5")
+    assert result == xml
+
+
+# --- _load_h5_for_replay ---
+
+
+def _write_stac_h5(path, qpos, config_yaml=None, kp_data=None, marker_sites=None):
+    with h5py.File(path, "w") as f:
+        f.create_dataset("qpos", data=qpos)
+        if config_yaml is not None:
+            f.create_dataset("config", data=np.bytes_(config_yaml))
+        if kp_data is not None:
+            f.create_dataset("kp_data", data=kp_data)
+        if marker_sites is not None:
+            f.create_dataset("marker_sites", data=marker_sites)
+
+
+def test_load_h5_basic(tmp_path):
+    qpos = np.random.randn(10, 7)
+    _write_stac_h5(tmp_path / "test.h5", qpos)
+
+    data = _load_h5_for_replay(tmp_path / "test.h5")
+    np.testing.assert_array_equal(data["qpos"], qpos)
+    assert "config" not in data
+
+
+def test_load_h5_with_config(tmp_path):
+    qpos = np.random.randn(5, 7)
+    cfg = "model:\n  MJCF_PATH: models/rodent.xml\n  SCALE_FACTOR: 0.9\n"
+    _write_stac_h5(tmp_path / "test.h5", qpos, config_yaml=cfg)
+
+    data = _load_h5_for_replay(tmp_path / "test.h5")
+    assert data["config"]["model"]["MJCF_PATH"] == "models/rodent.xml"
+    assert data["config"]["model"]["SCALE_FACTOR"] == 0.9
+
+
+def test_load_h5_with_markers(tmp_path):
+    n_frames, n_kps = 10, 5
+    qpos = np.random.randn(n_frames, 7)
+    kp_data = np.random.randn(n_frames, n_kps * 3)
+    marker_sites = np.random.randn(n_frames, n_kps, 3)
+    _write_stac_h5(
+        tmp_path / "test.h5", qpos, kp_data=kp_data, marker_sites=marker_sites
+    )
+
+    data = _load_h5_for_replay(tmp_path / "test.h5")
+    np.testing.assert_array_equal(data["kp_data"], kp_data)
+    np.testing.assert_array_equal(data["marker_sites"], marker_sites)
+
+
+def test_load_h5_missing_qpos(tmp_path):
+    path = tmp_path / "bad.h5"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("kp_data", data=np.zeros((5, 3)))
+
+    with pytest.raises(ValueError, match="does not contain 'qpos'"):
+        _load_h5_for_replay(path)
+
+
+# --- _normalize_shapes ---
+
+
+def test_normalize_shapes_flat():
+    data = {
+        "qpos": np.random.randn(20, 7),
+        "kp_data": np.random.randn(20, 15),
+        "marker_sites": np.random.randn(20, 5, 3),
+    }
+    result = _normalize_shapes(data)
+    assert result["qpos"].shape == (20, 7)
+    assert result["kp_data"].shape == (20, 5, 3)
+    assert result["marker_sites"].shape == (20, 5, 3)
+
+
+def test_normalize_shapes_batched():
+    n_clips, n_per_clip, nq, n_kps = 3, 10, 7, 4
+    data = {
+        "qpos": np.random.randn(n_clips, n_per_clip, nq),
+        "kp_data": np.random.randn(n_clips, n_per_clip, n_kps * 3),
+        "marker_sites": np.random.randn(n_clips, n_per_clip, n_kps, 3),
+    }
+    result = _normalize_shapes(data)
+    assert result["qpos"].shape == (30, nq)
+    assert result["kp_data"].shape == (30, n_kps, 3)
+    assert result["marker_sites"].shape == (30, n_kps, 3)
+
+
+def test_normalize_shapes_no_markers():
+    data = {"qpos": np.random.randn(10, 7)}
+    result = _normalize_shapes(data)
+    assert result["qpos"].shape == (10, 7)
+    assert "kp_data" not in result
+
+
+# --- _detect_root_body ---
+
+
+@pytest.fixture
+def rodent_model():
+    return mujoco.MjModel.from_xml_path(str(RODENT_XML))
+
+
+def test_detect_root_body_auto(rodent_model):
+    bid = _detect_root_body(rodent_model)
+    name = mujoco.mj_id2name(rodent_model, mujoco.mjtObj.mjOBJ_BODY, bid)
+    assert name == "torso"
+
+
+def test_detect_root_body_explicit(rodent_model):
+    bid = _detect_root_body(rodent_model, "pelvis")
+    name = mujoco.mj_id2name(rodent_model, mujoco.mjtObj.mjOBJ_BODY, bid)
+    assert name == "pelvis"
+
+
+def test_detect_root_body_invalid(rodent_model):
+    with pytest.raises(ValueError, match="not found"):
+        _detect_root_body(rodent_model, "nonexistent_body")
+
+
+def test_detect_root_body_fallback():
+    spec = mujoco.MjSpec()
+    spec.worldbody.add_body(name="custom_root")
+    model = spec.compile()
+    bid = _detect_root_body(model)
+    assert bid == 1
+
+
+# --- _model_extent ---
+
+
+def test_model_extent_rodent(rodent_model):
+    extent = _model_extent(rodent_model)
+    assert extent > 0.0
+
+
+def test_model_extent_empty_model():
+    spec = mujoco.MjSpec()
+    model = spec.compile()
+    extent = _model_extent(model)
+    assert extent == 0.01  # fallback
+
+
+# --- CLI argument parsing ---
+
+
+def test_main_parse_args_help(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        from stac_mjx.replay_fit import main
+        import sys
+
+        sys.argv = ["stac-viewer", "--help"]
+        main()
+    assert exc_info.value.code == 0
+
+
+# --- replay() input validation ---
+
+
+def test_replay_missing_h5():
+    from stac_mjx.replay_fit import replay
+
+    with pytest.raises(FileNotFoundError, match="H5 file not found"):
+        replay("nonexistent.h5")
+
+
+def test_replay_non_stac_h5(tmp_path):
+    from stac_mjx.replay_fit import replay
+
+    path = tmp_path / "bad.h5"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("tracks", data=np.zeros((5, 3)))
+
+    with pytest.raises(ValueError, match="does not contain 'qpos'"):
+        replay(path)
+
+
+def test_replay_no_xml_no_config(tmp_path):
+    from stac_mjx.replay_fit import replay
+
+    path = tmp_path / "no_config.h5"
+    _write_stac_h5(path, np.random.randn(5, 7))
+
+    with pytest.raises(ValueError, match="No MJCF_PATH"):
+        replay(path)


### PR DESCRIPTION
## Summary
- Integrates the standalone `replay_fit.py` into the stac-mjx package as a general-purpose interactive MuJoCo viewer for STAC output H5 files
- Registers `stac-viewer` as a CLI entry point (`pip install` makes it available as a shell command)
- Exposes `stac_mjx.replay()` Python API for notebook/script use
- Auto-discovers XML model path, scale factor, FPS, and camera root body from the embedded H5 config — no manual configuration needed for typical use

## Screenshot
<img width="1818" height="1100" alt="stac-viewer-1" src="https://github.com/user-attachments/assets/2a0c3d2e-c084-4516-8065-e923116f1b33" />
<img width="1818" height="1100" alt="stac-viewer-2" src="https://github.com/user-attachments/assets/6b9dccb8-5ef5-4a42-a019-c4e4a11d039f" />


### Usage
```bash
# CLI
stac-viewer fit_offsets.h5
stac-viewer ik_only.h5 --xml models/rodent.xml --fps 60
stac-viewer fit.h5 --no-markers --root-body torso

# Python
from stac_mjx import replay
replay("fit_offsets.h5")
```

### Interactive controls
- **SPACE** — pause/play
- **LEFT/RIGHT** — step frames
- **UP/DOWN** — speed (0.1x–2.0x)
- **-/=** — nudge floor z
- Red spheres = input keypoints, Green spheres = fitted marker sites

## Test plan
- [x] Module imports cleanly (`from stac_mjx.replay_fit import replay`)
- [x] `stac-viewer --help` works after `pip install -e .`
- [x] Error handling: missing H5, non-STAC H5, missing XML all produce clear messages
- [x] Existing test suite passes (18/18, pre-existing `test_init_stac` config failure unchanged)
- [ ] Manual test with a real STAC output H5 file (needs fit_offsets/ik_only output)

Initial implementation from Hendrik at David Labonte Lab.
🤖 Generated with [Claude Code](https://claude.com/claude-code)